### PR TITLE
[#165905031] getMessages should not return rejected messages 

### DIFF
--- a/api/definitions.yaml
+++ b/api/definitions.yaml
@@ -149,11 +149,13 @@ MessageStatusValue:
     "FAILED": a permanent failure caused the process to exit with an error, no notification will be sent for this message
     "PROCESSED": the message was succesfully processed and is now stored in the user's inbox;
       we'll try to send a notification for each of the selected channels
+    "REJECTED": either the recipient does not exist, or the sender has been blocked
   x-extensible-enum:
     - ACCEPTED
     - THROTTLED
     - FAILED
     - PROCESSED
+    - REJECTED
   example: ACCEPTED
 MessageStatus:
   type: object

--- a/lib/__tests__/emailnotifications_queue_handler.test.ts
+++ b/lib/__tests__/emailnotifications_queue_handler.test.ts
@@ -52,7 +52,7 @@ import {
   NotificationAddressSourceEnum,
   NotificationModel
 } from "../models/notification";
-import { isTransient } from "../utils/errors";
+import { isTransientError } from "../utils/errors";
 
 import { NotificationEvent } from "../models/notification_event";
 
@@ -112,14 +112,11 @@ const aSenderMetadata: CreatedMessageEventSenderMetadata = {
 };
 
 const aNotificationEvent = {
-  message: {
-    ...aMessage,
-    content: {
-      markdown: aMessageBodyMarkdown,
-      subject: aMessageBodySubject
-    },
-    kind: "INewMessageWithContent"
+  content: {
+    markdown: aMessageBodyMarkdown,
+    subject: aMessageBodySubject
   },
+  message: aMessage,
   notificationId: aNotificationId,
   senderMetadata: aSenderMetadata
 };
@@ -132,10 +129,8 @@ const getMockNotificationEvent = (
 ) => {
   return NotificationEvent.decode(
     Object.assign({}, aNotificationEvent, {
-      message: {
-        ...aNotificationEvent.message,
-        content: messageContent
-      }
+      content: messageContent,
+      message: aNotificationEvent.message
     })
   ).getOrElseL(errs => {
     throw new Error(
@@ -232,7 +227,7 @@ describe("handleNotification", () => {
     );
     expect(isLeft(result)).toBeTruthy();
     if (isLeft(result)) {
-      expect(isTransient(result.value)).toBeTruthy();
+      expect(isTransientError(result.value)).toBeTruthy();
     }
   });
 
@@ -251,7 +246,7 @@ describe("handleNotification", () => {
 
     expect(isLeft(result)).toBeTruthy();
     if (isLeft(result)) {
-      expect(isTransient(result.value)).toBeTruthy();
+      expect(isTransientError(result.value)).toBeTruthy();
     }
   });
 
@@ -270,7 +265,7 @@ describe("handleNotification", () => {
 
     expect(isLeft(result)).toBeTruthy();
     if (isLeft(result)) {
-      expect(isTransient(result.value)).toBeFalsy();
+      expect(isTransientError(result.value)).toBeFalsy();
     }
   });
 
@@ -456,7 +451,7 @@ This is a message from the future!`.replace(/[ \n]+/g, "|")
 
     expect(isLeft(result)).toBeTruthy();
     if (isLeft(result)) {
-      expect(isTransient(result.value)).toBeTruthy();
+      expect(isTransientError(result.value)).toBeTruthy();
     }
   });
 });

--- a/lib/controllers/__tests__/messages.test.ts
+++ b/lib/controllers/__tests__/messages.test.ts
@@ -146,6 +146,7 @@ const aNewMessageWithoutContent: NewMessageWithoutContent = {
   fiscalCode: aFiscalCode,
   id: "A_MESSAGE_ID" as NonEmptyString,
   indexedId: "A_MESSAGE_ID" as NonEmptyString,
+  isPending: true,
   kind: "INewMessageWithoutContent",
   senderServiceId: "test" as ServiceId,
   senderUserId: "u123" as NonEmptyString,
@@ -297,14 +298,13 @@ describe("CreateMessageHandler", () => {
 
     expect<any>(mockContext.bindings).toEqual({
       createdMessage: {
+        content: {
+          markdown: aMessagePayload.content.markdown,
+          subject: aMessageSubject
+        },
         message: {
           ...aNewMessageWithoutContent,
-          content: {
-            markdown: aMessagePayload.content.markdown,
-            subject: aMessageSubject
-          },
-          createdAt: expect.any(Date),
-          kind: "INewMessageWithContent"
+          createdAt: expect.any(Date)
         },
         senderMetadata: {
           departmentName: "IT",
@@ -340,7 +340,7 @@ describe("CreateMessageHandler", () => {
     }
   });
 
-  it("should create a new message for a limited auhorization recipient", async () => {
+  it("should create a new message for a limited authorization recipient", async () => {
     const mockMessageModel = {
       create: jest.fn(() => right(aRetrievedMessageWithoutContent))
     };
@@ -388,14 +388,13 @@ describe("CreateMessageHandler", () => {
 
     expect<any>(mockContext.bindings).toEqual({
       createdMessage: {
+        content: {
+          markdown: aMessagePayload.content.markdown,
+          subject: aMessagePayload.content.subject
+        },
         message: {
           ...aNewMessageWithoutContent,
-          content: {
-            markdown: aMessagePayload.content.markdown,
-            subject: aMessagePayload.content.subject
-          },
-          createdAt: expect.any(Date),
-          kind: "INewMessageWithContent"
+          createdAt: expect.any(Date)
         },
         senderMetadata: {
           departmentName: "IT",
@@ -475,14 +474,13 @@ describe("CreateMessageHandler", () => {
 
     expect<any>(mockContext.bindings).toEqual({
       createdMessage: {
+        content: {
+          markdown: aMessagePayload.content.markdown,
+          subject: aCustomSubject
+        },
         message: {
           ...aNewMessageWithoutContent,
-          content: {
-            markdown: aMessagePayload.content.markdown,
-            subject: aCustomSubject
-          },
-          createdAt: expect.any(Date),
-          kind: "INewMessageWithContent"
+          createdAt: expect.any(Date)
         },
         senderMetadata: {
           departmentName: "IT",
@@ -569,17 +567,16 @@ describe("CreateMessageHandler", () => {
 
     expect<any>(mockContext.bindings).toEqual({
       createdMessage: {
+        content: {
+          markdown: messagePayload.content.markdown,
+          subject: messagePayload.content.subject
+        },
         defaultAddresses: {
           email: "test@example.com" as EmailAddress
         },
         message: {
           ...aNewMessageWithoutContent,
-          content: {
-            markdown: messagePayload.content.markdown,
-            subject: messagePayload.content.subject
-          },
-          createdAt: expect.any(Date),
-          kind: "INewMessageWithContent"
+          createdAt: expect.any(Date)
         },
         senderMetadata: {
           departmentName: "IT",
@@ -828,9 +825,7 @@ describe("CreateMessageHandler", () => {
 
     expect(mockContext.bindings as any).toMatchObject({
       createdMessage: {
-        message: {
-          content: { payment_data: { invalid_after_due_date: false } }
-        }
+        content: { payment_data: { invalid_after_due_date: false } }
       }
     });
 

--- a/lib/models/__tests__/created_message_event.test.ts
+++ b/lib/models/__tests__/created_message_event.test.ts
@@ -11,6 +11,10 @@ describe("", () => {
   it("should validate valid events CreatedMessageEvents", () => {
     const payloads: ReadonlyArray<any> = [
       {
+        content: {
+          markdown: aMessageBodyMarkdown,
+          subject: "test".repeat(10)
+        },
         defaultAddresses: { email: "federico@teamdigitale.governo.it" },
         message: {
           _attachments: "attachments/",
@@ -19,10 +23,6 @@ describe("", () => {
           _self:
             "dbs/LgNRAA==/colls/LgNRANj9nwA=/docs/LgNRANj9nwBgAAAAAAAAAA==/",
           _ts: 1505754168,
-          content: {
-            markdown: aMessageBodyMarkdown,
-            subject: "test".repeat(10)
-          },
           createdAt: new Date().toISOString(),
           fiscalCode: "FRLFRC73E04B157I",
           id: "01BTAZ2HS1PWDJERA510FDXYV4",

--- a/lib/models/__tests__/notification_event.test.ts
+++ b/lib/models/__tests__/notification_event.test.ts
@@ -27,7 +27,6 @@ const aMessageContent: MessageContent = {
 };
 
 const aMessage = {
-  content: aMessageContent,
   createdAt: new Date().toISOString(),
   fiscalCode: "FRLFRC74E04B157I",
   id: aMessageId,
@@ -49,6 +48,7 @@ describe("isNotificationEvent", () => {
   it("should return true for valid payloads", () => {
     const fixtures: ReadonlyArray<any> = [
       {
+        content: aMessageContent,
         message: aMessage,
         notificationId: aNotificationId,
         senderMetadata: aSenderMetadata

--- a/lib/models/created_message_event.ts
+++ b/lib/models/created_message_event.ts
@@ -6,16 +6,18 @@
  */
 
 import * as t from "io-ts";
+import { NonNegativeNumber } from "italia-ts-commons/lib/numbers";
 
+import { MessageContent } from "../api/definitions/MessageContent";
 import { NewMessageDefaultAddresses } from "../api/definitions/NewMessageDefaultAddresses";
 
-import { NewMessageWithContent } from "./message";
+import { NewMessageWithoutContent } from "./message";
 
-import { NonNegativeNumber } from "italia-ts-commons/lib/numbers";
 import { CreatedMessageEventSenderMetadata } from "./created_message_sender_metadata";
 
 const CreatedMessageEventR = t.interface({
-  message: NewMessageWithContent,
+  content: MessageContent,
+  message: NewMessageWithoutContent,
   senderMetadata: CreatedMessageEventSenderMetadata,
   serviceVersion: NonNegativeNumber
 });

--- a/lib/models/message.ts
+++ b/lib/models/message.ts
@@ -29,29 +29,37 @@ export const MESSAGE_MODEL_PK_FIELD = "fiscalCode";
 
 const MESSAGE_BLOB_STORAGE_SUFFIX = ".json";
 
-const MessageBase = t.interface(
-  {
-    // the fiscal code of the recipient
-    fiscalCode: FiscalCode,
+const MessageBaseR = t.interface({
+  // the fiscal code of the recipient
+  fiscalCode: FiscalCode,
 
-    // the identifier of the service of the sender
-    senderServiceId: ServiceId,
+  // the identifier of the service of the sender
+  senderServiceId: ServiceId,
 
-    // the userId of the sender (this is opaque and depends on the API gateway)
-    senderUserId: NonEmptyString,
+  // the userId of the sender (this is opaque and depends on the API gateway)
+  senderUserId: NonEmptyString,
 
-    // time to live in seconds
-    timeToLiveSeconds: TimeToLiveSeconds,
+  // time to live in seconds
+  timeToLiveSeconds: TimeToLiveSeconds,
 
-    // when the message was accepted by the system
-    createdAt: Timestamp,
+  // when the message was accepted by the system
+  createdAt: Timestamp,
 
-    // needed to order by id or to make range queries (ie. WHERE id > "string")
-    // see https://stackoverflow.com/questions/48710600/azure-cosmosdb-how-to-order-by-id
-    indexedId: NonEmptyString
-  },
-  "MessageBase"
-);
+  // needed to order by id or to make range queries (ie. WHERE id > "string")
+  // see https://stackoverflow.com/questions/48710600/azure-cosmosdb-how-to-order-by-id
+  indexedId: NonEmptyString
+});
+
+const MessageBaseO = t.partial({
+  // When true, the message is still being processed and should be
+  // hidden from the result of getMessages requests. This is needed to avoid
+  // cases where getMessages returns messages without content - i.e. messages
+  // that didn't pass the checks done by created_message_queue_handler before
+  // storing the message content.
+  isPending: t.boolean
+});
+
+const MessageBase = t.intersection([MessageBaseR, MessageBaseO], "MessageBase");
 
 /**
  * The attributes common to all types of Message

--- a/lib/models/notification_event.ts
+++ b/lib/models/notification_event.ts
@@ -2,8 +2,10 @@ import * as t from "io-ts";
 
 import { NonEmptyString } from "italia-ts-commons/lib/strings";
 
+import { MessageContent } from "../api/definitions/MessageContent";
+
 import { CreatedMessageEventSenderMetadata } from "./created_message_sender_metadata";
-import { NewMessageWithContent } from "./message";
+import { NewMessageWithoutContent } from "./message";
 
 /**
  * Payload of a notification event.
@@ -12,7 +14,8 @@ import { NewMessageWithContent } from "./message";
  * have been configured for that notification.
  */
 export const NotificationEvent = t.interface({
-  message: NewMessageWithContent,
+  content: MessageContent,
+  message: NewMessageWithoutContent,
   notificationId: NonEmptyString,
   senderMetadata: CreatedMessageEventSenderMetadata
 });

--- a/lib/utils/__tests__/documentdb.test.ts
+++ b/lib/utils/__tests__/documentdb.test.ts
@@ -428,6 +428,40 @@ describe("mapResultIterator", () => {
   });
 });
 
+describe("filterResultIterator", () => {
+  it("should filter the documents of the wrapped iterator", async () => {
+    const iteratorMock = {
+      executeNext: jest.fn()
+    };
+
+    iteratorMock.executeNext.mockImplementationOnce(() =>
+      Promise.resolve(right(some([1, 2, 3, 4, 5])))
+    );
+    iteratorMock.executeNext.mockImplementationOnce(() =>
+      Promise.resolve(right(none))
+    );
+
+    const filteredIterator = DocumentDbUtils.filterResultIterator(
+      iteratorMock as any,
+      (n: number) => n % 2 === 1
+    );
+
+    const result1 = await filteredIterator.executeNext();
+    await filteredIterator.executeNext();
+
+    expect(iteratorMock.executeNext).toHaveBeenCalledTimes(2);
+    expect(isRight(result1)).toBeTruthy();
+    if (isRight(result1)) {
+      expect(result1.value.isSome());
+      expect(result1.value.toUndefined()).toEqual([1, 3, 5]);
+    }
+    expect(isRight(result1)).toBeTruthy();
+    if (isRight(result1)) {
+      expect(result1.value.isNone());
+    }
+  });
+});
+
 describe("iteratorToArray", () => {
   it("should consume an iterator", async () => {
     const iteratorMock = {

--- a/lib/utils/errors.ts
+++ b/lib/utils/errors.ts
@@ -5,10 +5,21 @@
  */
 
 export enum ErrorTypes {
+  // a temporary error while processing the message (operation can be retried)
   TransientError = "TransientError",
+
+  // a permanent error while processing the message (operation cannot be retried)
   PermanentError = "PermanentError",
+
+  // triggered when an unknown error gets catched
   UnknownError = "UnknownError",
-  ExpiredError = "ExpiredError"
+
+  // message is expired, it couldn't be delivered withing the TTL
+  ExpiredError = "ExpiredError",
+
+  // a recipient error, either the profile is non existent or the sender isn't
+  // allowed by the recipient
+  RecipientError = "RecipientError"
 }
 
 interface IRuntimeError<T extends ErrorTypes> {
@@ -39,6 +50,9 @@ export const UnknownError = RuntimeError(ErrorTypes.UnknownError);
 export type ExpiredError = IRuntimeError<ErrorTypes.ExpiredError>;
 export const ExpiredError = RuntimeError(ErrorTypes.ExpiredError);
 
+export type RecipientError = IRuntimeError<ErrorTypes.RecipientError>;
+export const RecipientError = RuntimeError(ErrorTypes.RecipientError);
+
 /**
  * Construct a RuntimeError from an object.
  * Useful in try / catch blocks where the object caught is untyped.
@@ -58,10 +72,16 @@ export type RuntimeError =
   | TransientError
   | PermanentError
   | UnknownError
-  | ExpiredError;
+  | ExpiredError
+  | RecipientError;
 
-export const isTransient = (error: RuntimeError): error is TransientError =>
+export const isTransientError = (
+  error: RuntimeError
+): error is TransientError =>
   error.kind && error.kind === ErrorTypes.TransientError;
 
-export const isExpired = (error: RuntimeError): error is ExpiredError =>
+export const isExpiredError = (error: RuntimeError): error is ExpiredError =>
   error.kind && error.kind === ErrorTypes.ExpiredError;
+
+export const isRecipientError = (error: RuntimeError): error is ExpiredError =>
+  error.kind && error.kind === ErrorTypes.RecipientError;


### PR DESCRIPTION
This PR introduces:

1. a pending flag on the message metadata that gets used to filter out from the result of `getMessages` the messages that are being processed (or have been rejected)
1. a new `REJECTED` status for messages that have been rejected due to a non-existent profile or a blocked sender

TODO:

- [x] fix tests