### PR TITLE
[#166536717] Typo error in welcome message

### DIFF
--- a/lib/profile_events_queue_handler.ts
+++ b/lib/profile_events_queue_handler.ts
@@ -61,7 +61,7 @@ Scopri le funzioni e impara a usare l'app del cittadino.
 
 ### I messaggi
 IO ti consente di ricevere messaggi dalle Pubbliche Amministrazioni italiane, sia locali che nazionali, e all'occorrenza effettuare pagamenti.
-Puoi decidere da chi e come essere contattato, dalla sezione [servizi](ioit://PREFERENCES_SERVICES) di questa applicazione, e scegliere se inoltrare il messaggio anche al tuo indirizo email associato a SPID.
+Puoi decidere da chi e come essere contattato, dalla sezione [servizi](ioit://PREFERENCES_SERVICES) di questa applicazione, e scegliere se inoltrare il messaggio anche al tuo indirizzo email associato a SPID.
 
 ### I pagamenti
 


### PR DESCRIPTION
This PR fix the below typo error:

![image](https://user-images.githubusercontent.com/17931148/63002555-78959c80-be76-11e9-8cf7-ed2d95f036fa.png)
